### PR TITLE
changes git_client from boolean to string

### DIFF
--- a/defaults/main/1_main.yml
+++ b/defaults/main/1_main.yml
@@ -86,7 +86,7 @@ defaults_sem:
     telegram_alert: false
     slack_alert: false
     demo_mode: false
-    git_client: false
+    git_client: 'go_git' # can only be go_git or cmd_git
 
   ansible_config:  # ansible.cfg => https://docs.ansible.com/ansible/latest/reference_appendices/config.html
     defaults:  # section

--- a/templates/etc/semaphore/config.json.j2
+++ b/templates/etc/semaphore/config.json.j2
@@ -62,5 +62,5 @@
   "ldap_enable": {{ cnf_n.ldap_enable | json_bool }},
   "ldap_needtls": {{ cnf_n.ldap_needtls | json_bool }},
   "demo_mode": {{ cnf_n.demo_mode | json_bool }},
-  "git_client": "{{ cnf_n.git_client | json_bool }}"
+  "git_client": "{{ cnf_n.git_client }}"
  }


### PR DESCRIPTION
Install fails because git_client has an invalid entry.  Sets default to go_git.

Tested on version 2.9.37